### PR TITLE
Fix sizeof

### DIFF
--- a/bin/predictions.py
+++ b/bin/predictions.py
@@ -33,6 +33,7 @@ from dask.distributed import wait
 from jinja2 import Template
 import os
 import pickle
+import cloudpickle 
 import tqdm
 import time
 import joblib
@@ -40,6 +41,16 @@ import lmdb
 
 joblib.memory._build_func_identifier = better_build_func_identifier
 
+
+import dask.sizeof
+
+@dask.sizeof.sizeof.register(dict)
+def sizeof_python_dict(d):
+    return len(cloudpickle.dumps(d))
+
+@dask.sizeof.sizeof.register(list)
+def sizeof_python_list(l):
+    return len(cloudpickle.dumps(l))
 
 # Load inputs and define global vars
 if __name__ == "__main__":

--- a/catlas/dask_utils.py
+++ b/catlas/dask_utils.py
@@ -70,16 +70,6 @@ def bag_split_individual_partitions(bag):
     return Bag(graph, name=new_name, npartitions=sum(nsplits))
 
 
-class SizeDict(dict):
-    def __sizeof__(self):
-        return len(pickle.dumps(self))
-
-
-class SizeList(list):
-    def __sizeof__(self):
-        return len(pickle.dumps(self))
-
-
 def to_pickles(b, path, name_function=None, compute=True, **kwargs):
     files = open_files(
         path,

--- a/catlas/enumerate_slabs_adslabs.py
+++ b/catlas/enumerate_slabs_adslabs.py
@@ -6,7 +6,6 @@ from ocdata.adsorbates import Adsorbate
 from ocdata.bulk_obj import Bulk
 import copy
 from ocpmodels.preprocessing import AtomsToGraphs
-from .dask_utils import SizeDict, SizeList
 import logging
 import torch
 
@@ -27,8 +26,6 @@ def enumerate_slabs(bulk_dict, max_miller=2):
 
     logger = logging.getLogger("distributed.worker")
     logger.info("enumerate_slabs_started: %s" % str(bulk_dict))
-
-    bulk_dict = SizeDict(bulk_dict)
 
     bulk_obj = CustomBulk(bulk_dict["bulk_atoms"])
 
@@ -63,7 +60,7 @@ def enumerate_adslabs(surface_ads_combo):
     surface_dict, ads_dict = surface_ads_combo
 
     # Prep the new adslab result from the adsorbate and surface info dicts
-    adslab_result = SizeList()
+    adslab_result = []
 
     adsorbate_obj = CustomAdsorbate(
         ads_dict["adsorbate_atoms"],
@@ -81,7 +78,7 @@ def enumerate_adslabs(surface_ads_combo):
 
 def convert_adslabs_to_graphs(adslab_result, max_neighbors=50, cutoff=6):
 
-    graph_dict = SizeDict()
+    graph_dict = {}
 
     a2g = AtomsToGraphs(
         max_neigh=max_neighbors,
@@ -111,7 +108,7 @@ def merge_surface_adsorbate_combo(surface_adsorbate_combo):
     surface_dict, ads_dict = surface_adsorbate_combo
 
     # Prep the new adslab result from the adsorbate and surface info dicts
-    adslab_result = SizeDict()
+    adslab_result = {}
     adslab_result.update(copy.deepcopy(surface_dict))
     adslab_result.update(copy.deepcopy(ads_dict))
 

--- a/catlas/load_bulk_structures.py
+++ b/catlas/load_bulk_structures.py
@@ -37,21 +37,19 @@ def load_bulks(bulk_path):
         bulk_list = []
         for row in db.select():
             bulk_list.append(
-                    {
-                        "bulk_atoms": row.toatoms(),
-                        "bulk_id": row.bulk_id,
-                        "bulk_data_source": db_name,
-                        "bulk_natoms": row.natoms,
-                        "bulk_xc": "RPBE",
-                        "bulk_nelements": len(
-                            np.unique(row.toatoms().get_chemical_symbols())
-                        ),
-                        "bulk_elements": np.unique(
-                            row.toatoms().get_chemical_symbols()
-                        ),
-                        "bulk_e_above_hull": row.energy_above_hull,
-                        "bulk_band_gap": row.band_gap,
-                    }
+                {
+                    "bulk_atoms": row.toatoms(),
+                    "bulk_id": row.bulk_id,
+                    "bulk_data_source": db_name,
+                    "bulk_natoms": row.natoms,
+                    "bulk_xc": "RPBE",
+                    "bulk_nelements": len(
+                        np.unique(row.toatoms().get_chemical_symbols())
+                    ),
+                    "bulk_elements": np.unique(row.toatoms().get_chemical_symbols()),
+                    "bulk_e_above_hull": row.energy_above_hull,
+                    "bulk_band_gap": row.band_gap,
+                }
             )
 
         return bulk_list

--- a/catlas/load_bulk_structures.py
+++ b/catlas/load_bulk_structures.py
@@ -3,7 +3,6 @@ from ase.db import connect
 import os.path
 import numpy as np
 import pandas as pd
-from .dask_utils import SizeDict
 import catlas
 
 required_fields = (
@@ -38,7 +37,6 @@ def load_bulks(bulk_path):
         bulk_list = []
         for row in db.select():
             bulk_list.append(
-                SizeDict(
                     {
                         "bulk_atoms": row.toatoms(),
                         "bulk_id": row.bulk_id,
@@ -54,7 +52,6 @@ def load_bulks(bulk_path):
                         "bulk_e_above_hull": row.energy_above_hull,
                         "bulk_band_gap": row.band_gap,
                     }
-                )
             )
 
         return bulk_list


### PR DESCRIPTION
Dask implemented a better method to make custom sizeof functions and register them. When  they did that, the SizeDict/SizeList we made stopped doing anything. The dask cluster does not correctly track data usage right now. 

This is an easy fix as we just have to register the sizeof methods in dask and it works well. See the "managed" data in the Dask Status UI, which now has a more reasonable number.