### PR TITLE
Unique clustername test

### DIFF
--- a/.github/workflows/test_catlas.yml
+++ b/.github/workflows/test_catlas.yml
@@ -83,9 +83,10 @@ jobs:
     - name: Startup dask cluster
       run: |
         sed -i "s/catlas-hybrid-cluster/catlas-hybrid-cluster-$GITHUB_RUN_ID/g" catlas/configs/dask_cluster/dask_operator/catlas-hybrid-cluster.yml
+        sed -i "s/catlas-hybrid-cluster/catlas-hybrid-cluster-$GITHUB_RUN_ID/g" catlas/configs/dask_cluster/dask_operator/dask_connect.py
         kubectl apply -f catlas/configs/dask_cluster/dask_operator/catlas-hybrid-cluster.yml
         sleep 10
-        kubectl scale --replicas=2 daskworkergroup catlas-hybrid-cluster-default-worker-group
+        kubectl scale --replicas=2 daskworkergroup catlas-hybrid-cluster-$GITHUB_RUN_ID-default-worker-group
     - name: Test cpu relaxation inference with kubecluster
       run: |
         cd catlas
@@ -93,9 +94,9 @@ jobs:
     - name: Test gpu relaxation with kubecluster
       run: |
         cd catlas
-        kubectl scale --replicas=1 daskworkergroup catlas-hybrid-cluster-gpu-worker-group
+        kubectl scale --replicas=1 daskworkergroup catlas-hybrid-cluster-$GITHUB_RUN_ID-gpu-worker-group
         python bin/predictions.py configs/tests/test_gpu_relax.yml configs/dask_cluster/dask_operator/dask_connect.py
     - name: Shut down dask cluster
       if: always()
       run: |
-        kubectl delete daskcluster catlas-hybrid-cluster
+        kubectl delete daskcluster catlas-hybrid-cluster-$GITHUB_RUN_ID

--- a/.github/workflows/test_catlas.yml
+++ b/.github/workflows/test_catlas.yml
@@ -82,6 +82,7 @@ jobs:
         python setup.py develop
     - name: Startup dask cluster
       run: |
+        sed "s/catlas-hybrid-cluster/catlas-hybrid-cluster-$GITHUB_RUN_ID/g" catlas/configs/dask_cluster/dask_operator/catlas-hybrid-cluster.yml
         kubectl apply -f catlas/configs/dask_cluster/dask_operator/catlas-hybrid-cluster.yml
         sleep 10
         kubectl scale --replicas=2 daskworkergroup catlas-hybrid-cluster-default-worker-group

--- a/.github/workflows/test_catlas.yml
+++ b/.github/workflows/test_catlas.yml
@@ -82,7 +82,7 @@ jobs:
         python setup.py develop
     - name: Startup dask cluster
       run: |
-        sed "s/catlas-hybrid-cluster/catlas-hybrid-cluster-$GITHUB_RUN_ID/g" catlas/configs/dask_cluster/dask_operator/catlas-hybrid-cluster.yml
+        sed -i "s/catlas-hybrid-cluster/catlas-hybrid-cluster-$GITHUB_RUN_ID/g" catlas/configs/dask_cluster/dask_operator/catlas-hybrid-cluster.yml
         kubectl apply -f catlas/configs/dask_cluster/dask_operator/catlas-hybrid-cluster.yml
         sleep 10
         kubectl scale --replicas=2 daskworkergroup catlas-hybrid-cluster-default-worker-group


### PR DESCRIPTION
Change the github tests so that they use unique clusters. This was a primary cause for the failures in github actions (if two tests ran at the same time, one could shut down the other and cause errors). 