### PR TITLE
Dask operator automated screens

### DIFF
--- a/.github/workflows/automated_screens.yml
+++ b/.github/workflows/automated_screens.yml
@@ -27,7 +27,6 @@ jobs:
         context: ulissigroup-desktops-fqdn
       id: setcontext
     - run: |
-        sudo apt update && sudo apt install git-lfs
         mkdir -p /home/jovyan/shared-scratch/catlas_runners/$GITHUB_RUN_ID
         mkdir -p /home/jovyan/shared-scratch/catlas_runners/$GITHUB_RUN_ID/catlas
         ln -s /home/jovyan/shared-scratch/catlas_runners/$GITHUB_RUN_ID/catlas
@@ -35,18 +34,33 @@ jobs:
         rsync -a /home/jovyan/ocp /home/jovyan/shared-scratch/catlas_runners/$GITHUB_RUN_ID/
     - uses: actions/checkout@v3
       with:
-        lfs: true
         path: catlas
-    - run: |
+    - name: Test direct inference with kubecluster
+      run: |
         cd catlas
+        ln -s /home/jovyan/shared-scratch/catlas/ocp_checkpoints
         python setup.py develop
-        python bin/predictions.py configs/automated_screens/nitrides_CO2RR.yml configs/dask_cluster/github_kube_cluster/github_kube_hybrid_cluster.py
+    - name: Startup dask cluster
+      run: |
+        sed -i "s/catlas-hybrid-cluster/catlas-hybrid-cluster-$GITHUB_RUN_ID/g" catlas/configs/dask_cluster/dask_operator/catlas-hybrid-cluster.yml
+        sed -i "s/catlas-hybrid-cluster/catlas-hybrid-cluster-$GITHUB_RUN_ID/g" catlas/configs/dask_cluster/dask_operator/dask_connect.py
+        kubectl apply -f catlas/configs/dask_cluster/dask_operator/catlas-hybrid-cluster.yml
+        sleep 10
+        kubectl scale --replicas=2 daskworkergroup catlas-hybrid-cluster-$GITHUB_RUN_ID-default-worker-group
+        kubectl scale --replicas=1 daskworkergroup catlas-hybrid-cluster-$GITHUB_RUN_ID-gpu-worker-group
     - run: |
         cd catlas
-        python bin/predictions.py configs/automated_screens/intermetallics_ORR.yml configs/dask_cluster/github_kube_cluster/github_kube_hybrid_cluster.py
+        python bin/predictions.py configs/automated_screens/nitrides_CO2RR.yml configs/dask_cluster/dask_operator/dask_connect.py
     - run: |
         cd catlas
-        python bin/predictions.py configs/automated_screens/intermetallics_HER.yml configs/dask_cluster/github_kube_cluster/github_kube_hybrid_cluster.py
+        python bin/predictions.py configs/automated_screens/intermetallics_ORR.yml configs/dask_cluster/dask_operator/dask_connect.py
     - run: |
         cd catlas
-        python bin/predictions.py configs/automated_screens/intermetallics_CO2RR.yml configs/dask_cluster/github_kube_cluster/github_kube_hybrid_cluster.py
+        python bin/predictions.py configs/automated_screens/intermetallics_HER.yml configs/dask_cluster/dask_operator/dask_connect.py
+    - run: |
+        cd catlas
+        python bin/predictions.py configs/automated_screens/intermetallics_CO2RR.yml configs/dask_cluster/dask_operator/dask_connect.py
+    - name: Shut down dask cluster
+      if: always()
+      run: |
+        kubectl delete daskcluster catlas-hybrid-cluster-$GITHUB_RUN_ID

--- a/configs/automated_screens/intermetallics_CO2RR.yaml
+++ b/configs/automated_screens/intermetallics_CO2RR.yaml
@@ -5,20 +5,19 @@ input_options:
 
 output_options:
   pickle_final_output: True # True pickles the resulting predictions
-  run_name: '{{ GITHUB_RUN_ID }}'
+  run_name: 'intermetallics_CO2RR_{{ GITHUB_RUN_ID }}'
   verbose: False
-  make_parity_plots: True
 
 bulk_filters:
   filter_by_element_groups: ['transition_metal']
   filter_by_object_size: 40 # 60
 
 adsorbate_filters:
-  filter_by_smiles: ['*OH', '*O']
+  filter_by_smiles: ['*H', '*CO','*OH','*CHO']
 
 slab_filters:
   filter_by_object_size: 90
-  filter_by_max_miller_index: 1 # Planar surfaces only like Pt111
+  filter_by_max_miller_index: 2
 
 adslab_prediction_steps:
 - gpu: true

--- a/configs/automated_screens/intermetallics_CO2RR.yaml
+++ b/configs/automated_screens/intermetallics_CO2RR.yaml
@@ -1,7 +1,8 @@
 memory_cache_location: '/home/jovyan/shared-scratch/catlas/cache_github'
 
 input_options:
-  bulk_file: 'catlas/bulk_structures/ocdata_bulks.db'
+  bulk_file: 'catlas/bulk_structures/ocp_bulks_w_properties.db'
+  adsorbate_file: 'catlas/adsorbate_structures/adsorbates.pkl'
 
 output_options:
   pickle_final_output: True # True pickles the resulting predictions

--- a/configs/automated_screens/intermetallics_CO2RR.yaml
+++ b/configs/automated_screens/intermetallics_CO2RR.yaml
@@ -6,6 +6,7 @@ input_options:
 
 output_options:
   pickle_final_output: True # True pickles the resulting predictions
+  pickle_intermediate_outputs: False
   run_name: 'intermetallics_CO2RR_{{ GITHUB_RUN_ID }}'
   verbose: False
 

--- a/configs/automated_screens/intermetallics_HER.yml
+++ b/configs/automated_screens/intermetallics_HER.yml
@@ -1,7 +1,8 @@
 memory_cache_location: '/home/jovyan/shared-scratch/catlas/cache_github'
 
 input_options:
-  bulk_file: 'catlas/bulk_structures/ocdata_bulks.db'
+  bulk_file: 'catlas/bulk_structures/ocp_bulks_w_properties.db'
+  adsorbate_file: 'catlas/adsorbate_structures/adsorbates.pkl'
 
 output_options:
   pickle_final_output: True # True pickles the resulting predictions

--- a/configs/automated_screens/intermetallics_HER.yml
+++ b/configs/automated_screens/intermetallics_HER.yml
@@ -6,6 +6,7 @@ input_options:
 
 output_options:
   pickle_final_output: True # True pickles the resulting predictions
+  pickle_intermediate_outputs: False
   run_name: '{{ GITHUB_RUN_ID }}'
   make_parity_plots: True
   verbose: False

--- a/configs/automated_screens/intermetallics_HER.yml
+++ b/configs/automated_screens/intermetallics_HER.yml
@@ -10,7 +10,7 @@ output_options:
   verbose: False
 
 bulk_filters:
-  filter_by_acceptable_elements: ['Sc', 'Ti', 'V', 'Cr', 'Mn', 'Fe', 'Co', 'Ni', 'Cu', 'Zn', 'Y', 'Zr', 'Nb', 'Mo', 'Tc', 'Ru', 'Rh', 'Pd', 'Ag', 'Cd', 'Ta', 'W', 'Re', 'Os', 'Ir', 'Pt', 'Au', 'Hg', 'Al', 'Ga', 'Sn', 'Pb', 'Bi', 'In']
+  filter_by_element_groups: ['transition_metal']
   filter_by_object_size: 40 # 60
 
 adsorbate_filters:

--- a/configs/automated_screens/intermetallics_ORR.yml
+++ b/configs/automated_screens/intermetallics_ORR.yml
@@ -1,7 +1,8 @@
 memory_cache_location: '/home/jovyan/shared-scratch/catlas/cache_github'
 
 input_options:
-  bulk_file: 'catlas/bulk_structures/ocdata_bulks.db'
+  bulk_file: 'catlas/bulk_structures/ocp_bulks_w_properties.db'
+  adsorbate_file: 'catlas/adsorbate_structures/adsorbates.pkl'
 
 output_options:
   pickle_final_output: True # True pickles the resulting predictions

--- a/configs/automated_screens/intermetallics_ORR.yml
+++ b/configs/automated_screens/intermetallics_ORR.yml
@@ -6,6 +6,7 @@ input_options:
 
 output_options:
   pickle_final_output: True # True pickles the resulting predictions
+  pickle_intermediate_outputs: False
   run_name: '{{ GITHUB_RUN_ID }}'
   verbose: False
   make_parity_plots: True

--- a/configs/automated_screens/nitrides_CO2RR.yml
+++ b/configs/automated_screens/nitrides_CO2RR.yml
@@ -6,6 +6,7 @@ input_options:
 
 output_options:
   pickle_final_output: True # True pickles the resulting predictions
+  pickle_intermediate_outputs: False
   run_name: 'nitrides_CO2RR_{{ GITHUB_RUN_ID }}'
   verbose: False
 

--- a/configs/automated_screens/nitrides_CO2RR.yml
+++ b/configs/automated_screens/nitrides_CO2RR.yml
@@ -1,7 +1,8 @@
 memory_cache_location: '/home/jovyan/shared-scratch/catlas/cache_github'
 
 input_options:
-  bulk_file: 'catlas/bulk_structures/ocdata_bulks.db'
+  bulk_file: 'catlas/bulk_structures/ocp_bulks_w_properties.db'
+  adsorbate_file: 'catlas/adsorbate_structures/adsorbates.pkl'
 
 output_options:
   pickle_final_output: True # True pickles the resulting predictions

--- a/configs/dask_cluster/dask_operator/catlas-hybrid-cluster.yml
+++ b/configs/dask_cluster/dask_operator/catlas-hybrid-cluster.yml
@@ -76,12 +76,13 @@ spec:
             path: /health
           initialDelaySeconds: 5
           periodSeconds: 10
-        livenessProbe:
-          httpGet:
-            port: http-dashboard
-            path: /health
-          initialDelaySeconds: 15
-          periodSeconds: 20
+        resources:
+          limits:
+            cpu: "4"
+            memory: 10G
+          requests:
+            cpu: "4"
+            memory: 10G
     service:
       type: ClusterIP
       selector:


### PR DESCRIPTION
Update the yamls for the various standard screens, and also remove the liveliness probe on the dask scheduler in the operator spec.